### PR TITLE
Update TinyBlog activities in roadmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,8 +313,6 @@ If you are interesting by really advanced notions close to black magic ;-) It ex
 <span class="label label-info">Redo</span> Coding a Counter</li>
 <li>🐥
 <span class="label label-warning">Exercise</span> Expressions and Messages</li>
-<li>🐥
-<span class="label label-warning">Exercise</span> TinyBlog: Presentation and Model</li>
 <li>
 🌶 <span class="label label-danger">Challenge</span> Challenge 0</li>
                 </ol>

--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@ Understanding Messages</li>
 <span class="label label-warning">Exercise</span> Solution: Expressions and Messages</li>
 <li>🐥
 <span class="label label-warning">Exercise</span> Expression Results</li>
-<li>🐥
+<li>🌐
 <span class="label label-warning">Exercise</span> TinyBlog (Chapters 1 and 2)</li>
 <li>
 🌶 <span class="label label-danger">Challenge</span> Solution: Challenge 0</li>
@@ -434,7 +434,7 @@ Understanding Messages</li>
 🐥
 <span class="label label-warning">Exercise</span> Rewriting Expressions</li>
 <li>
-🐥
+🌐
 <span class="label label-warning">Exercise</span> TinyBlog (Chapter 3)</li>
 
 <li>

--- a/index.html
+++ b/index.html
@@ -367,7 +367,7 @@ Understanding Messages</li>
 <li>🐥
 <span class="label label-warning">Exercise</span> Expression Results</li>
 <li>🐥
-<span class="label label-warning">Exercise</span> TinyBlog: Extending and Testing the Model</li>
+<span class="label label-warning">Exercise</span> TinyBlog (Chapters 1 and 2)</li>
 <li>
 🌶 <span class="label label-danger">Challenge</span> Solution: Challenge 0</li>
 <li>
@@ -435,7 +435,7 @@ Understanding Messages</li>
 <span class="label label-warning">Exercise</span> Rewriting Expressions</li>
 <li>
 🐥
-<span class="label label-warning">Exercise</span> TinyBlog: A Simple Teapot Web Interface</li>
+<span class="label label-warning">Exercise</span> TinyBlog (Chapter 3)</li>
 
 <li>
 							 🌶 <span class="label label-danger">Challenge</span> Solution: Challenge 1</li>
@@ -504,10 +504,7 @@ Understanding Messages</li>
 
 <li>
 🌐
-<span class="label label-warning">Exercise</span> TinyBlog: Data Persitency using Voyage and Mongo</li>
-<li>
-🌐
-<span class="label label-warning">Exercise</span> TinyBlog: Building a Web Interface with Seaside</li>
+<span class="label label-warning">Exercise</span> TinyBlog (Chapters 4 to 7)</li>
 <li>
 🌐
 <span class="label label-warning">Exercise</span> Building a Simple Contact Book Application</li>
@@ -569,7 +566,7 @@ Understanding Messages</li>
 <span class="label label-success">Live</span> GTInspector 2: Inspect Files and Directories</li>
 
 						  <li>🌐
-<span class="label label-warning">Exercise</span> TinyBlog: Building an Admin Seaside Web Interface with Magritte</li>
+<span class="label label-warning">Exercise</span> TinyBlog (Chapters 8 and 9)</li>
 
 <li>🐥
 <span class="label label-warning">Exercise</span> TinyChat</li>
@@ -619,9 +616,6 @@ Understanding Messages</li>
 
 <li>🐥
 <span class="label label-success">Live</span> GTInspector 4: Build Custom Tab Views for your Objects</li>
-
-<li>🌐
-<span class="label label-warning">Exercise</span> TinyBlog: Deployment</li>
 
 <li>🌶 <span class="label label-danger">Challenge</span> Solution: Challenge 4</li>
 <li>🌶 <span class="label label-danger">Challenge</span> Challenge 5</li>


### PR DESCRIPTION
To match the [Pharo Mooc Roadmap](http://rmod-pharo-mooc.lille.inria.fr/MOOC/PharoMOOC/PharoMoocRoadmap.pdf
)

**Change TinyBlog 🐥 to 🌐**
As the "How to follow this MOOC?" section says:

for newbies:
>...you can skip the Seaside/Mongo and tinyBlog exercises.

for web:
>...focus on tinychat and tinyblog.