### PR TITLE
Fix broken Pharo documentation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@ If you are interesting by really advanced notions close to black magic ;-) It ex
 			   <section id="resources">
                 <h2>Resources</h2>
                 <p>
-You can find free and online resources in the <a href="http://pharo.org/documentation/">Documentation</a> page. We recommend the Updated Pharo by Example book, the Pharo cheat-sheet, and the new book Learning Object-Oriented Programming, Design and TDD with Pharo on <a href="http://books.pharo.org/">http://books.pharo.org</a>
+You can find free and online resources in the <a href="https://www.pharo.org/documentation">Documentation</a> page. We recommend the Updated Pharo by Example book, the Pharo cheat-sheet, and the new book Learning Object-Oriented Programming, Design and TDD with Pharo on <a href="http://books.pharo.org/">http://books.pharo.org</a>
                 </p>
             </section>
 


### PR DESCRIPTION
https://pharo.org/documentation/ is a broken link.

https://www.pharo.org/documentation (with `www`) is the working link.

😄 